### PR TITLE
Use gunicorn for Cove docker container

### DIFF
--- a/dockers/cove/Dockerfile
+++ b/dockers/cove/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && \
     apt-get -y install git vim htop gettext && \
     git clone https://github.com/OpenDataServices/cove.git /opt/cove && \
     git fetch && \
-    pip3 install cython && \
     pip3 install -r requirements_iati.txt && \
+    pip3 install gunicorn && \
     python manage.py migrate && \
     python manage.py compilemessages && \
     mkdir -p media && \
@@ -20,7 +20,7 @@ RUN apt-get update && \
 
 COPY process.xml.sh /usr/local/bin/process.xml.sh
 COPY process.csv.sh /usr/local/bin/process.csv.sh
-RUN echo "#!/bin/bash\n\nif [ ! -z \"\$PROCESS_DATA\" ]; then\n/usr/local/bin/process.sh\nexit \$?\nfi\n\n/usr/local/bin/update.sh\ncd /opt/cove\nexport DJANGO_SETTINGS_MODULE=$DJANGO_SETTINGS_MODULE\npython3 manage.py migrate\npython3 manage.py compilemessages\npython3 manage.py runserver 0.0.0.0:8000" > /usr/local/bin/startup.sh
+RUN echo "#!/bin/bash\n\nif [ ! -z \"\$PROCESS_DATA\" ]; then\n/usr/local/bin/process.sh\nexit \$?\nfi\n\n/usr/local/bin/update.sh\ncd /opt/cove\nexport DJANGO_SETTINGS_MODULE=$DJANGO_SETTINGS_MODULE\npython3 manage.py migrate\npython3 manage.py compilemessages\ngunicorn cove_iati.wsgi -b 0.0.0.0:8000" > /usr/local/bin/startup.sh
 
 RUN chmod 777 /usr/local/bin/*.sh
 


### PR DESCRIPTION
Realised whilst doing this that it only matters if you run the CoVE web interface. If you're not, this can be ignored.

mange.py runserver is not recommended for production https://docs.djangoproject.com/en/1.8/ref/django-admin/#runserver-port-or-address-port
I've set up gunicorn in this PR instead of runserver, you'd also want to set up nginx to servers /static/ and /media/
Ideally you should also be specifying environment variable DEBUG=False and ALLOWED_HOSTS to an appropriate value.